### PR TITLE
V1.6.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.thesummergrinch</groupId>
     <artifactId>MCManHunt</artifactId>
-    <version>1.6.6</version>
+    <version>1.6.7</version>
     <packaging>jar</packaging>
 
     <name>MCManHunt</name>

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/MCManHunt.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/MCManHunt.java
@@ -32,6 +32,7 @@ import io.github.thesummergrinch.mcmanhunt.eventhandlers.OnPlayerRespawnEventHan
 import io.github.thesummergrinch.mcmanhunt.game.gamecontrols.Game;
 import io.github.thesummergrinch.mcmanhunt.game.gamecontrols.GameState;
 import io.github.thesummergrinch.mcmanhunt.game.players.PlayerState;
+import io.github.thesummergrinch.mcmanhunt.io.data.SavedGamesLoader;
 import io.github.thesummergrinch.mcmanhunt.io.lang.LanguageFileLoader;
 import io.github.thesummergrinch.mcmanhunt.io.settings.DefaultSettingsContainer;
 import io.github.thesummergrinch.mcmanhunt.io.settings.FileConfigurationLoader;
@@ -53,16 +54,15 @@ public final class MCManHunt extends JavaPlugin {
         // Plugin startup logic
         registerSerializableClasses();
         FileConfigurationLoader.getInstance().loadDefaultSettings("settings");
-        GameCache.getInstance().getGameCacheFromSave("game-cache");
+        GameCache.getInstance().getGameCacheFromSave("saved-games");
         this.saveConfig();
         loadLanguageFile();
         registerEventHandlers();
         registerCommands();
         enableMetrics();
         checkForUpdate();
-        if (DefaultSettingsContainer.getInstance().getSetting("bungeecord" +
-                "-enabled").equalsIgnoreCase("true")) {
-            //TODO register Outgoing channel
+        if (DefaultSettingsContainer.getInstance().getBoolean("bungeecord" +
+                "-enabled")) {
             this.getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
         }
 
@@ -135,12 +135,14 @@ public final class MCManHunt extends JavaPlugin {
      */
     private void enableMetrics() {
 
-        if (DefaultSettingsContainer.getInstance().getSetting("first-run").equals("true")) {
+        if (DefaultSettingsContainer.getInstance().getBoolean("first-run")) {
 
-            DefaultSettingsContainer.getInstance().setSetting("first-run", "false");
+            DefaultSettingsContainer.getInstance().setBoolean("first-run",
+                    false);
             getLogger().log(Level.INFO, LanguageFileLoader.getInstance().getString("metrics-enabled-on-next-launch"));
 
-        } else if (DefaultSettingsContainer.getInstance().getSetting("allow-metrics").equals("true")) {
+        } else if (DefaultSettingsContainer.getInstance().getBoolean("allow" +
+                "-metrics")) {
 
             final int pluginID = 8784;
 
@@ -160,10 +162,10 @@ public final class MCManHunt extends JavaPlugin {
      */
     private void saveConfigFile() {
 
-        FileConfigurationLoader.getInstance().saveItemToConfig("game-cache", GameCache.getInstance());
         FileConfigurationLoader.getInstance().saveItemToConfig("settings", DefaultSettingsContainer.getInstance());
-
         this.saveConfig();
+
+        SavedGamesLoader.getInstance().saveGameCache(GameCache.getInstance());
 
     }
 
@@ -173,7 +175,8 @@ public final class MCManHunt extends JavaPlugin {
      */
     private void checkForUpdate() {
 
-        if (Boolean.parseBoolean(DefaultSettingsContainer.getInstance().getSetting("enable-update-checking"))) {
+        if (DefaultSettingsContainer.getInstance().getBoolean(
+                "enable-update-checking")) {
 
             new UpdateChecker(this, 83665).getVersion(version -> {
 

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/cache/GameCache.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/cache/GameCache.java
@@ -2,7 +2,7 @@ package io.github.thesummergrinch.mcmanhunt.cache;
 
 import io.github.thesummergrinch.mcmanhunt.game.gamecontrols.Game;
 import io.github.thesummergrinch.mcmanhunt.game.gamecontrols.GameFlowState;
-import io.github.thesummergrinch.mcmanhunt.io.settings.FileConfigurationLoader;
+import io.github.thesummergrinch.mcmanhunt.io.data.SavedGamesLoader;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -135,7 +135,7 @@ public final class GameCache implements ConfigurationSerializable {
      */
     public void getGameCacheFromSave(final String key) {
 
-        instance = FileConfigurationLoader.getInstance().loadGames(key);
+        instance = SavedGamesLoader.getInstance().loadSavedGames(key);
         GameCache.getInstance().getAllGames().forEach(entry -> gameCache.put(entry.getKey(), entry.getValue()));
 
     }

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/cache/GameCache.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/cache/GameCache.java
@@ -179,4 +179,8 @@ public final class GameCache implements ConfigurationSerializable {
 
     }
 
+    public boolean containsKey(final String key) {
+        return gameCache.containsKey(key);
+    }
+
 }

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/commands/game/op/debug/DebugCommandExecutor.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/commands/game/op/debug/DebugCommandExecutor.java
@@ -1,5 +1,9 @@
 package io.github.thesummergrinch.mcmanhunt.commands.game.op.debug;
 
+import io.github.thesummergrinch.mcmanhunt.cache.GameCache;
+import io.github.thesummergrinch.mcmanhunt.events.ManHuntWinEvent;
+import io.github.thesummergrinch.mcmanhunt.io.settings.DefaultSettingsContainer;
+import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -8,14 +12,26 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class DebugCommandExecutor implements CommandExecutor, TabCompleter {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (sender.isOp() && sender instanceof Player) {
-            //TODO add Debug-functions
+        if (DefaultSettingsContainer.getInstance().getInteger("debug-level") <= 0) {
+            sender.sendMessage("The debug-level is set to 0. To enable " +
+                    "debugging features, raise the debug-level to a valid " +
+                    "number in the config.yml.");
+            return true;
+        }
+        if (sender.isOp() && sender instanceof Player && args != null && args.length >= 1) {
+            if (args[0].equalsIgnoreCase("winevent") && args.length >= 2) {
+                if (GameCache.getInstance().containsKey(args[1])) {
+                    Bukkit.getPluginManager().callEvent(new ManHuntWinEvent(args[1],
+                            GameCache.getInstance().getGameFromCache(args[1]).getHunterUUIDs()));
+                }
+            }
             return true;
         } else {
             return false;
@@ -24,6 +40,15 @@ public class DebugCommandExecutor implements CommandExecutor, TabCompleter {
 
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
-        return null;
+        final List<String> options = new ArrayList<>();
+        if (args.length <= 1) {
+            options.add("winevent");
+            return options;
+        } else if (args.length == 2) {
+            if (args[0].equalsIgnoreCase("winevent")) {
+                return GameCache.getInstance().getGameNamesAsList();
+            }
+        }
+        return options;
     }
 }

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/commands/game/op/gameflow/StopGameCommandExecutor.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/commands/game/op/gameflow/StopGameCommandExecutor.java
@@ -5,6 +5,7 @@ import io.github.thesummergrinch.mcmanhunt.cache.PlayerStateCache;
 import io.github.thesummergrinch.mcmanhunt.game.gamecontrols.Game;
 import io.github.thesummergrinch.mcmanhunt.game.players.PlayerState;
 import io.github.thesummergrinch.mcmanhunt.io.lang.LanguageFileLoader;
+import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -45,6 +46,8 @@ public class StopGameCommandExecutor implements CommandExecutor, TabCompleter {
 
                         sender.sendMessage(LanguageFileLoader.getInstance().getString("specified-game-not-exist"));
 
+                        Bukkit.getServer().dispatchCommand(sender, "listgames");
+
                         return true;
 
                     }
@@ -52,6 +55,8 @@ public class StopGameCommandExecutor implements CommandExecutor, TabCompleter {
                 } else {
 
                     sender.sendMessage(LanguageFileLoader.getInstance().getString("specified-game-not-exist"));
+
+                    Bukkit.getServer().dispatchCommand(sender, "listgames");
 
                     return true;
 

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/eventhandlers/OnPlayerLeaveEventHandler.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/eventhandlers/OnPlayerLeaveEventHandler.java
@@ -1,0 +1,72 @@
+package io.github.thesummergrinch.mcmanhunt.eventhandlers;
+
+import io.github.thesummergrinch.mcmanhunt.cache.GameCache;
+import io.github.thesummergrinch.mcmanhunt.cache.PlayerStateCache;
+import io.github.thesummergrinch.mcmanhunt.events.ManHuntWinEvent;
+import io.github.thesummergrinch.mcmanhunt.game.gamecontrols.Game;
+import io.github.thesummergrinch.mcmanhunt.game.gamecontrols.GameFlowState;
+import io.github.thesummergrinch.mcmanhunt.game.players.PlayerRole;
+import io.github.thesummergrinch.mcmanhunt.game.players.PlayerState;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class OnPlayerLeaveEventHandler implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onEvent(final PlayerQuitEvent event) {
+
+        final PlayerState playerState =
+                PlayerStateCache.getInstance()
+                        .getPlayerState(event.getPlayer().getUniqueId());
+
+        if (playerState.isInGame()) {
+            final Game game = GameCache.getInstance()
+                    .getGameFromCache(playerState.getGameName());
+            if (game.getGameFlowState() == GameFlowState.RUNNING) {
+                if (playerState.getPlayerRole() == PlayerRole.HUNTER) {
+                    AtomicBoolean quit = new AtomicBoolean(true);
+                    game.getHunters().forEach((playerState1) -> {
+                        if (playerState1.isOnline() && playerState1.getPlayerUUID()
+                                != playerState.getPlayerUUID()) {
+                            quit.set(false);
+                            return;
+                        }
+                    });
+                    if (quit.get()) {
+                        Bukkit.getPluginManager().callEvent(
+                                new ManHuntWinEvent
+                                        (
+                                                game.getName(),
+                                                game.getRunnerUUIDs()
+                                        )
+                        );
+                    }
+                } else if (playerState.getPlayerRole() == PlayerRole.RUNNER) {
+                    AtomicBoolean quit = new AtomicBoolean(true);
+                    game.getRunners().forEach((playerState1) -> {
+                        if (playerState1.isOnline() && playerState1.getPlayerUUID()
+                                != playerState.getPlayerUUID()) {
+                            quit.set(false);
+                            return;
+                        }
+                    });
+                    if (quit.get()) {
+                        Bukkit.getPluginManager().callEvent(
+                                new ManHuntWinEvent
+                                        (
+                                                game.getName(),
+                                                game.getHunterUUIDs()
+                                        )
+                        );
+                    }
+                }
+            }
+        }
+    } // TODO Test this
+
+}

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/game/gamecontrols/Game.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/game/gamecontrols/Game.java
@@ -368,8 +368,7 @@ public final class Game implements ConfigurationSerializable {
         // Clear advancements of the Players, if the corresponding flag in
         // the config.yml is set to 'true'.
         if (DefaultSettingsContainer.getInstance()
-                .getSetting("clear-advancements-after-game")
-                .equalsIgnoreCase("true")) {
+                .getBoolean("clear-advancements-after-game")) {
             this.getAllPlayers().forEach((playerState -> {
                 revokeAdvancements(Bukkit.getPlayer(playerState.getPlayerUUID()));
             }));
@@ -423,8 +422,8 @@ public final class Game implements ConfigurationSerializable {
 
         // Connect players to the given BungeeCord-lobby, if BungeeCord is
         // enabled in the config.yml
-        if (DefaultSettingsContainer.getInstance().getSetting("bungeecord" +
-                "-enabled").equalsIgnoreCase("true")) {
+        if (DefaultSettingsContainer.getInstance().getBoolean("bungeecord" +
+                "-enabled")) {
             this.gameState.getPlayersInGame().forEach((uuid, playerState) -> {
                 if (!playerState.isOnline()) return;
                 connectPlayerToHub(Bukkit.getPlayer(uuid));

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/game/gamecontrols/Game.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/game/gamecontrols/Game.java
@@ -430,15 +430,19 @@ public final class Game implements ConfigurationSerializable {
             });
         } else {
 
+            final String baseWorldName =
+                    DefaultSettingsContainer.getInstance().getSetting(
+                            "base-world");
+
             this.gameState.getPlayersInGame().forEach((uuid, playerState) -> {
 
                 if (!playerState.isOnline()) return;
 
                 final Player player = Bukkit.getPlayer(uuid);
 
-                player.setBedSpawnLocation(Bukkit.getWorld("world").getSpawnLocation(), true);
-                player.teleport(Bukkit.getWorld(DefaultSettingsContainer.getInstance().getSetting("base-world"))
-                        .getSpawnLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN);
+                player.setBedSpawnLocation(Bukkit.getWorld(baseWorldName).getSpawnLocation(), true);
+                player.teleport(Bukkit.getWorld(baseWorldName).getSpawnLocation(),
+                        PlayerTeleportEvent.TeleportCause.PLUGIN);
 
             });
         }

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/game/gamecontrols/Game.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/game/gamecontrols/Game.java
@@ -437,7 +437,7 @@ public final class Game implements ConfigurationSerializable {
                 final Player player = Bukkit.getPlayer(uuid);
 
                 player.setBedSpawnLocation(Bukkit.getWorld("world").getSpawnLocation(), true);
-                player.teleport(Bukkit.getWorld("world")
+                player.teleport(Bukkit.getWorld(DefaultSettingsContainer.getInstance().getSetting("base-world"))
                         .getSpawnLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN);
 
             });

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/game/gamecontrols/GameState.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/game/gamecontrols/GameState.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 public final class GameState implements ConfigurationSerializable {
@@ -384,7 +385,26 @@ public final class GameState implements ConfigurationSerializable {
 
     protected boolean isEligibleForStart() {
 
-        return ((getNumberOfHunters() >= 1 && getNumberOfRunners() >= 1) || (playerRolesRandomized && playersInGame.size() >= 2));
+        final AtomicBoolean runnersReady = new AtomicBoolean(false);
+        final AtomicBoolean huntersReady = new AtomicBoolean(false);
+
+        for (PlayerState runner : this.getRunners()) {
+            if (runner.isOnline()) {
+                runnersReady.set(true);
+                break;
+            }
+        }
+
+        for(PlayerState hunter : this.getHunters()) {
+            if (hunter.isOnline()) {
+                huntersReady.set(true);
+                break;
+            }
+        }
+
+        return (runnersReady.get() && huntersReady.get())
+                && ((this.getNumberOfHunters() >= 1 && this.getNumberOfRunners() >= 1)
+                || (this.playerRolesRandomized && this.playersInGame.size() >= 2));
 
     }
 

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/game/gamecontrols/GameState.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/game/gamecontrols/GameState.java
@@ -47,13 +47,14 @@ public final class GameState implements ConfigurationSerializable {
         this.gameFlowState = GameFlowState.DEFAULT;
         this.gameName = this.gameUniverse.getName();
         this.playersInGame = new HashMap<>();
-        this.isCompassEnabledInNether = Boolean.parseBoolean(DefaultSettingsContainer.getInstance()
-                .getSetting("compass-enabled-in-nether"));
+        this.isCompassEnabledInNether = DefaultSettingsContainer.getInstance()
+                .getBoolean("compass-enabled-in-nether");
         this.defaultGameDifficulty = gameUniverse.getWorld(gameName).getDifficulty();
         this.worldSpawn = gameUniverse.getWorld(gameName).getSpawnLocation();
-        this.playerRolesRandomized = Boolean.parseBoolean((DefaultSettingsContainer.getInstance()
-                .getSetting("player-roles-randomized")));
-        this.headstart = Long.parseLong(DefaultSettingsContainer.getInstance().getSetting("default-headstart"));
+        this.playerRolesRandomized = (DefaultSettingsContainer.getInstance()
+                .getBoolean("player-roles-randomized"));
+        this.headstart = DefaultSettingsContainer.getInstance().getInteger(
+                "headstart");
 
     }
 

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/io/data/SavedGamesLoader.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/io/data/SavedGamesLoader.java
@@ -1,0 +1,85 @@
+package io.github.thesummergrinch.mcmanhunt.io.data;
+
+import io.github.thesummergrinch.mcmanhunt.MCManHunt;
+import io.github.thesummergrinch.mcmanhunt.cache.GameCache;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.Plugin;
+
+import java.io.File;
+import java.io.IOException;
+
+public class SavedGamesLoader {
+
+    private static volatile SavedGamesLoader INSTANCE;
+
+    private final FileConfiguration savedGamesFileConfiguration;
+    private final Plugin plugin;
+
+    private File dataFile;
+
+    private SavedGamesLoader() {
+
+        this.plugin = MCManHunt.getPlugin(MCManHunt.class);
+
+        try {
+            this.dataFile = createDataFile(this.plugin);
+        } catch (IOException exception) {
+            this.plugin.getLogger().severe("Could not create saved-game file." +
+                    " Please contact developer: https://www.github" +
+                    ".com/TheSummerGrinch");
+        }
+
+        this.savedGamesFileConfiguration =
+                YamlConfiguration.loadConfiguration(this.dataFile);
+
+    }
+
+    public static SavedGamesLoader getInstance() {
+        if (SavedGamesLoader.INSTANCE != null) return INSTANCE;
+        synchronized (SavedGamesLoader.class) {
+            if (SavedGamesLoader.INSTANCE == null) SavedGamesLoader.INSTANCE
+                    = new SavedGamesLoader();
+            return INSTANCE;
+        }
+    }
+
+    private File createDataFile(final Plugin plugin) throws IOException {
+        final File pluginDataFolder = plugin.getDataFolder();
+
+        if (!pluginDataFolder.exists()) {
+            pluginDataFolder.mkdir();
+        }
+
+        final File gameDataFolder =
+                new File(pluginDataFolder + File.separator + "GameData");
+
+        if (!gameDataFolder.exists()) {
+            gameDataFolder.mkdir();
+        }
+
+        final File gameDataFile = new File(gameDataFolder + File.separator +
+                "SavedGames.yml");
+
+        if (!gameDataFile.exists() || !gameDataFile.isFile()) {
+            gameDataFile.createNewFile();
+        }
+        return gameDataFile;
+    }
+
+    public void saveGameCache(final GameCache gameCache) {
+        this.savedGamesFileConfiguration.set("saved-games", gameCache);
+        try {
+            this.savedGamesFileConfiguration.save(this.dataFile);
+        } catch (IOException exception) {
+            this.plugin.getLogger().severe("Could not save games... Please " +
+                    "contact developer: https://www.github" +
+                    ".com/TheSummerGrinch");
+        }
+    }
+
+    public GameCache loadSavedGames(final String key) {
+        return this.savedGamesFileConfiguration.getObject(key, GameCache.class);
+    }
+
+}

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/io/settings/DefaultSettingsContainer.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/io/settings/DefaultSettingsContainer.java
@@ -1,6 +1,8 @@
 package io.github.thesummergrinch.mcmanhunt.io.settings;
 
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,10 +14,16 @@ public final class DefaultSettingsContainer implements ConfigurationSerializable
     private static volatile DefaultSettingsContainer instance;
 
     private final Map<String, Object> defaultSettings;
+    private final Map<String, Integer> integerSettings;
+    private final Map<String, Boolean> booleanSettings;
+    private final Map<String, String> stringSettings;
 
     private DefaultSettingsContainer() {
 
         this.defaultSettings = new HashMap<>();
+        this.integerSettings = new HashMap<>();
+        this.booleanSettings = new HashMap<>();
+        this.stringSettings = new HashMap<>();
 
     }
 
@@ -51,92 +59,134 @@ public final class DefaultSettingsContainer implements ConfigurationSerializable
 
         HashMap<String, Object> settingsMap = new HashMap<>();
 
-        settingsMap.put("settings", defaultSettings);
+
 
         return settingsMap;
 
     }
 
-    public int getInteger(final String key) {
+    private boolean isBoolean(final Object possibleBoolean) {
 
-        Object value = this.defaultSettings.get(key);
-
-        if (value instanceof Integer) return (Integer) value;
-
-        value =
-                FileConfigurationLoader.getInstance().getDefaultSettings().get(key);
-
-        if (value instanceof Integer) {
-            this.defaultSettings.put(key, value);
-            return (Integer) value;
-        }
-
-        return -1;
-
-    }
-
-    public boolean getBoolean(final String key) {
-
-        Object value = this.defaultSettings.get(key);
-
-        if (value instanceof Boolean) return (Boolean) value;
-
-        value =
-                FileConfigurationLoader.getInstance().getDefaultSettings().get(key);
-
-        if (value instanceof Boolean) {
-            this.defaultSettings.put(key, value);
-            return (Boolean) value;
+        if (possibleBoolean instanceof Boolean) {
+            return true;
+        } else if (possibleBoolean instanceof String) {
+            return ((String) possibleBoolean).equalsIgnoreCase("true")
+                    || ((String) possibleBoolean).equalsIgnoreCase("false");
         }
 
         return false;
 
     }
 
-    @Nullable
-    public String getSetting(final String key) {
-
-        Object value = this.defaultSettings.get(key);
-
-        if (value instanceof String) return (String) value;
-
-        value = FileConfigurationLoader.getInstance().getDefaultSettings().get(key);
-
-        if (value instanceof String) {
-            setSetting(key, value);
-            return (String) value;
+    private boolean isInteger(@NotNull final Object possibleInteger) {
+        if (possibleInteger instanceof Integer) {
+            return true;
+        } else if (possibleInteger instanceof String) {
+            int length = ((String) possibleInteger).length();
+            if (length == 0) {
+                return false;
+            }
+            int i = 0;
+            if (((String) possibleInteger).charAt(0) == '-') {
+                if (length == 1) {
+                    return false;
+                }
+                i = 1;
+            }
+            for (; i < length; i++) {
+                char c = ((String) possibleInteger).charAt(i);
+                if (c < '0' || c > '9') {
+                    return false;
+                }
+            }
+            return true;
         }
+        return false;
+    }
 
-        return null;
+    public int getInteger(final String key) {
+
+        return this.integerSettings.get(key) != null ?
+                this.integerSettings.get(key) : -1;
 
     }
 
-    public void setSetting(final String key, final Object value) {
+    public boolean getBoolean(final String key) {
 
-        this.defaultSettings.put(key, value);
+        return this.booleanSettings.get(key) != null ?
+                this.booleanSettings.get(key) : false;
+
+    }
+
+    @Nullable
+    public String getSetting(final String key) {
+
+        return this.stringSettings.get(key) != null ?
+                this.stringSettings.get(key) : "";
+
+    }
+
+    public void setSetting(final String key, final String value) {
+
+        this.stringSettings.put(key, value);
 
     }
 
     public void setSettings(final Map<String, Object> settings) {
 
-        this.defaultSettings.putAll(settings);
+        settings.forEach((key, value) -> {
+            if (value instanceof Boolean) {
+                setBoolean(key, (Boolean) value);
+            } else if (value instanceof Integer) {
+                setInteger(key, (Integer) value);
+            } else if (value instanceof String) {
+                setSetting(key, (String) value);
+            }
+        });
 
     }
 
     public void setBoolean(final String key, boolean value) {
 
-        this.defaultSettings.put(key, value);
+        this.booleanSettings.put(key, value);
 
     }
 
     public void setInteger(final String key, int value) {
 
-        this.defaultSettings.put(key, value);
+        this.integerSettings.put(key, value);
 
     }
 
     public boolean contains(final String key) {
-        return this.defaultSettings.containsKey(key);
+        return this.booleanSettings.containsKey(key)
+                || this.integerSettings.containsKey(key)
+                || this.stringSettings.containsKey(key);
+    }
+
+    public Map<String, Object> getAllSettings() {
+        final Map<String, Object> allSettings = new HashMap<>();
+        allSettings.putAll(this.booleanSettings);
+        allSettings.putAll(this.integerSettings);
+        allSettings.putAll(this.stringSettings);
+        return allSettings;
+    }
+
+    public void saveSettings(final Plugin plugin) {
+
+        FileConfiguration fileConfiguration = plugin.getConfig();
+
+        this.stringSettings.forEach(fileConfiguration::set);
+        this.integerSettings.forEach(fileConfiguration::set);
+        this.booleanSettings.forEach(fileConfiguration::set);
+
+        plugin.saveConfig();
+
+    }
+
+    @Deprecated
+    public Map<String, Object> getDefaultSettings() {
+        return this.defaultSettings;
     }
 
 }

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/io/settings/DefaultSettingsContainer.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/io/settings/DefaultSettingsContainer.java
@@ -2,6 +2,7 @@ package io.github.thesummergrinch.mcmanhunt.io.settings;
 
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -10,7 +11,7 @@ public final class DefaultSettingsContainer implements ConfigurationSerializable
 
     private static volatile DefaultSettingsContainer instance;
 
-    private final Map<String, String> defaultSettings;
+    private final Map<String, Object> defaultSettings;
 
     private DefaultSettingsContainer() {
 
@@ -56,29 +57,86 @@ public final class DefaultSettingsContainer implements ConfigurationSerializable
 
     }
 
-    public String getSetting(final String key) {
+    public int getInteger(final String key) {
 
-        String value = this.defaultSettings.get(key);
+        Object value = this.defaultSettings.get(key);
 
-        if (value != null) return value;
+        if (value instanceof Integer) return (Integer) value;
 
-        value = FileConfigurationLoader.getInstance().getDefaultSettings().get(key);
+        value =
+                FileConfigurationLoader.getInstance().getDefaultSettings().get(key);
 
-        if (value != null) setSetting(key, value);
+        if (value instanceof Integer) {
+            this.defaultSettings.put(key, value);
+            return (Integer) value;
+        }
 
-        return value;
+        return -1;
 
     }
 
-    public void setSetting(final String key, final String value) {
+    public boolean getBoolean(final String key) {
+
+        Object value = this.defaultSettings.get(key);
+
+        if (value instanceof Boolean) return (Boolean) value;
+
+        value =
+                FileConfigurationLoader.getInstance().getDefaultSettings().get(key);
+
+        if (value instanceof Boolean) {
+            this.defaultSettings.put(key, value);
+            return (Boolean) value;
+        }
+
+        return false;
+
+    }
+
+    @Nullable
+    public String getSetting(final String key) {
+
+        Object value = this.defaultSettings.get(key);
+
+        if (value instanceof String) return (String) value;
+
+        value = FileConfigurationLoader.getInstance().getDefaultSettings().get(key);
+
+        if (value instanceof String) {
+            setSetting(key, value);
+            return (String) value;
+        }
+
+        return null;
+
+    }
+
+    public void setSetting(final String key, final Object value) {
 
         this.defaultSettings.put(key, value);
 
     }
 
-    public void setSettings(final Map<String, String> settings) {
+    public void setSettings(final Map<String, Object> settings) {
 
         this.defaultSettings.putAll(settings);
 
     }
+
+    public void setBoolean(final String key, boolean value) {
+
+        this.defaultSettings.put(key, value);
+
+    }
+
+    public void setInteger(final String key, int value) {
+
+        this.defaultSettings.put(key, value);
+
+    }
+
+    public boolean contains(final String key) {
+        return this.defaultSettings.containsKey(key);
+    }
+
 }

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/io/settings/FileConfigurationLoader.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/io/settings/FileConfigurationLoader.java
@@ -49,6 +49,7 @@ public final class FileConfigurationLoader {
      * @param key - path to the serialized {@link GameCache} object.
      * @return - the {@link GameCache}-object stored in the config.yml.
      */
+    @Deprecated
     public GameCache loadGames(final String key) {
 
         return fileConfiguration.getObject(key, GameCache.class);
@@ -64,7 +65,17 @@ public final class FileConfigurationLoader {
 
         DefaultSettingsContainer defaultSettingsContainer = fileConfiguration.getObject(key, DefaultSettingsContainer.class);
 
-        if (defaultSettingsContainer != null) return DefaultSettingsContainer.getInstance();
+        if (defaultSettingsContainer != null) {
+
+            if (defaultSettingsContainer.getInteger("config-version") < (int) this.getDefaultSettings().get("config-version")) {
+                this.getDefaultSettings().forEach((name, value) -> {
+                    if (!defaultSettingsContainer.contains(name))
+                        defaultSettingsContainer.setSetting(name, value);
+                });
+            }
+
+            return DefaultSettingsContainer.getInstance();
+        }
 
         DefaultSettingsContainer.getInstance().setSettings(getDefaultSettings());
         this.fileConfiguration.set("settings", DefaultSettingsContainer.getInstance());
@@ -79,20 +90,21 @@ public final class FileConfigurationLoader {
      * launch.
      * @return - the {@link HashMap} containing default settings.
      */
-    public HashMap<String, String> getDefaultSettings() {
+    public HashMap<String, Object> getDefaultSettings() {
 
-        return new HashMap<String, String>() {
+        return new HashMap<String, Object>() {
             {
-                put("first-run", "true");
-                put("allow-metrics", "true");
-                put("compass-enabled-in-nether", "false");
-                put("player-roles-randomized", "false");
-                put("default-headstart", "30");
-                put("enable-update-checking", "true");
+                put("config-version", 1);
+                put("first-run", true);
+                put("allow-metrics", true);
+                put("compass-enabled-in-nether", false);
+                put("player-roles-randomized", false);
+                put("default-headstart", 30);
+                put("enable-update-checking", true);
                 put("locale", "enGB");
-                put("bungeecord-enabled", "false");
+                put("bungeecord-enabled", false);
                 put("bungeecord-hub-name", "hub");
-                put("clear-advancements-after-game", "false");
+                put("clear-advancements-after-game", false);
             }
         };
 

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/io/settings/LegacyConfigConverter.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/io/settings/LegacyConfigConverter.java
@@ -1,0 +1,91 @@
+package io.github.thesummergrinch.mcmanhunt.io.settings;
+
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.Map;
+import java.util.Scanner;
+
+public class LegacyConfigConverter {
+
+    private static volatile LegacyConfigConverter instance;
+
+    private LegacyConfigConverter() {}
+
+    public static LegacyConfigConverter getInstance() {
+        if (instance != null) return instance;
+        synchronized (LegacyConfigConverter.class) {
+            if (instance == null) instance = new LegacyConfigConverter();
+        }
+        return instance;
+    }
+
+    @Deprecated
+    public void convertLegacyConfig(final DefaultSettingsContainer legacySettingsContainer) {
+
+        Map<String, Object> legacySettings =
+                legacySettingsContainer.getAllSettings();
+        legacySettings.forEach((key, value) -> {
+            final String valueString = (String) value;
+            if (isBoolean(valueString)) {
+                DefaultSettingsContainer.getInstance().setBoolean(key,
+                        Boolean.parseBoolean(valueString));
+            } else if (isInteger(valueString)) {
+                DefaultSettingsContainer.getInstance().setInteger(key,
+                        Integer.parseInt(valueString));
+            }
+        });
+
+        FileConfigurationLoader.getInstance().getDefaultSettings().forEach((key, value) -> {
+            if (!DefaultSettingsContainer.getInstance().contains(key))
+                if (value instanceof Boolean) {
+                    DefaultSettingsContainer.getInstance().setBoolean(key,
+                            (Boolean) value);
+                } else if (value instanceof Integer) {
+                    DefaultSettingsContainer.getInstance().setInteger(key,
+                            (Integer) value);
+                } else if (value instanceof String) {
+                    DefaultSettingsContainer.getInstance().setSetting(key,
+                            (String) value);
+                }
+        });
+
+        legacySettings.remove("settings");
+        legacySettings.remove("game-cache");
+
+    }
+
+    public DefaultSettingsContainer convertLegacyConfig(final FileConfiguration fileConfiguration) {
+
+        DefaultSettingsContainer settingsContainer =
+                fileConfiguration.getObject("settings",
+                        DefaultSettingsContainer.class);
+
+        Map<String, Object> settings = settingsContainer.getDefaultSettings();
+
+        settings.forEach((key, value) -> {
+            if (value instanceof Boolean) {
+                settingsContainer.setBoolean(key, (Boolean) value);
+            } else if (value instanceof Integer) {
+                settingsContainer.setInteger(key, (Integer) value);
+            } else if (value instanceof String) {
+                settingsContainer.setSetting(key, (String) value);
+            }
+        });
+
+        return DefaultSettingsContainer.getInstance();
+
+    }
+
+    private boolean isBoolean(final String possibleBoolean) {
+        return possibleBoolean.equalsIgnoreCase("true")
+                || possibleBoolean.equalsIgnoreCase("false");
+    }
+
+    private boolean isInteger(final String possibleInteger) {
+        Scanner sc = new Scanner(possibleInteger.trim());
+        if(!sc.hasNextInt()) return false;
+        sc.nextInt();
+        return !sc.hasNext();
+    }
+
+}

--- a/src/main/java/io/github/thesummergrinch/mcmanhunt/utils/ConfigUtils.java
+++ b/src/main/java/io/github/thesummergrinch/mcmanhunt/utils/ConfigUtils.java
@@ -1,0 +1,21 @@
+package io.github.thesummergrinch.mcmanhunt.utils;
+
+public abstract class ConfigUtils {
+
+    public static boolean isBoolean(final String arg) {
+        return arg.equalsIgnoreCase("true")
+                || arg.equalsIgnoreCase("false");
+    }
+
+    public static boolean isBoolean(final Object arg) {
+//        if (arg instanceof Boolean) return true;
+//        if (arg instanceof String) return isBoolean((String) arg);
+//        return false;
+
+        return arg instanceof Boolean
+                || (arg instanceof String
+                && (((String) arg).equalsIgnoreCase("true")
+                || ((String) arg).equalsIgnoreCase("false")));
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,54 @@
+# Default config for MCManHunt
+# Author: TheSummerGrinch
+# Website: https://www.github.com/TheSummerGrinch
+# Support at https://www.github.com/TheSummerGrinch or via Discord on https://discord.gg/N5dYy3F
+
+config-version: 1
+
+# Tells the plugin whether it's the first time it's being run. If so, metrics
+# will be automatically disabled until the next start, to allow the user to
+# disable metrics.
+first-run: true
+
+# Allows the user to disable/enable metrics.
+allow-metrics: true
+
+# Sets whether or not the tracking-compasses should point to the runner in
+# the Nether.
+compass-enabled-in-nether: false
+
+# Sets whether or not roles should be randomized by default.
+player-roles-randomized: false
+
+# The default headstart for runners. Valid range: 0 <= x <= Integer.MAX_VALUE
+default-headstart: 15
+
+# Allows the user to enable/disable automatic update-checking. The plugin
+# does not automatically download updates.
+enable-update-checking: true
+
+# The Locale, used to set the language used by the MCManHunt-plugin.
+# Available languages: enGB, enUS, nlNL
+locale: 'enGB'
+
+# Sets whether or not the server is part of a BungeeCord-network. If enabled,
+# will atempt to teleport players to the hub-server when a game ends.
+bungeecord-enabled: false
+
+# The name of the hub-server, or whichever server the players should
+# connected to when a ManHunt-game ends.
+bungeecord-hub-name: 'hub'
+
+# Sets whether the advancements of (participating) players should be cleared
+# when a ManHunt-game ends.
+clear-advancements-after-game: false
+
+# Sets the debug-level. Unlocks debugging features per (valid) level. Do not
+# edit unless you know what you're doing, or have received instruction from
+# the developer to do so.
+debug-level: 0
+
+# Name of the world that players should be teleported to if BungeeCord is
+# disabled. Usually the default world will be called 'world', but certain
+# server providers, such as ShockByte, don't use the default name.
+base-world: 'world'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -80,6 +80,10 @@ commands:
     description: Allows the user to set the language MCManHunt will use in its messages.
     usage: /setlanguage [language] (e.g. /setlanguage enGB)
     permission: mcmanhunt.game.op
+  mhdebug:
+    description: Allows access to various debug-commands.
+    usage: /mhdebug [function]
+    permission: mcmanhunt.game.op
 permissions:
   mcmanhunt.game.op:
     description: Allows the user access to op-commands related to the MCManHunt-plugin.


### PR DESCRIPTION
Changelog:

- New Config-options!
- Configurable that allows you to automatically clear the advancements of players that participated in a ManHunt-game!
- Converter for legacy config-files!
- Improved the way we validate whether a game can start.
- Added a configurable option to change which world players should be sent to, once a game ends. (if bungeecord is disabled).
- Added a debug-command. Currently little functionality, but will make development and tech-support a lot easier in the future!

Closes #14 